### PR TITLE
Camera Matrix files

### DIFF
--- a/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_1080P_config.json
+++ b/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_1080P_config.json
@@ -1,0 +1,54 @@
+{
+    "dewarpConfigArray": [
+        {
+            "source_image": {
+                "width": 1920,
+                "height": 1080
+            },
+            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
+            "dewarpType": "FISHEYE_DEWARP",
+            "scale": {
+                "roix": 0,
+                "roiy": 0,
+                "factor": 1.0
+            },
+            "split": {
+                "horizon_line": 540,
+                "vertical_line_up": 960,
+                "vertical_line_down": 960
+            },
+            "bypass": false,
+            "hflip": false,
+            "vflip": false,
+            "camera_matrix": [
+                1258.283,
+                0.0,
+                980.600,
+                0.0,
+                1263.618,
+                528.483,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "distortion_coeff": [
+                -0.02585,
+                -0.01841,
+                -0.002730,
+                0.004726,
+                0.01456
+            ],
+            "perspective": [
+                1.0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1
+            ]
+        }
+    ]
+}

--- a/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_4K_config.json
+++ b/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_4K_config.json
@@ -1,0 +1,54 @@
+{
+    "dewarpConfigArray": [
+        {
+            "source_image": {
+                "width": 3840,
+                "height": 2160
+            },
+            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
+            "dewarpType": "FISHEYE_DEWARP",
+            "scale": {
+                "roix": 0,
+                "roiy": 0,
+                "factor": 1.0
+            },
+            "split": {
+                "horizon_line": 540,
+                "vertical_line_up": 960,
+                "vertical_line_down": 960
+            },
+            "bypass": false,
+            "hflip": false,
+            "vflip": false,
+            "camera_matrix": [
+                2516.566,
+                0.0,
+                1961.200,
+                0.0,
+                2527.236,
+                1056.966,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "distortion_coeff": [
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "perspective": [
+                1.0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added the dewarp config files to have the os08a20 camera start with the correct camera matrix for the focal length.
The config files should end up in `/usr/share/imx8-isp/dewarp_config/sensor_dwe_os08a20_4K_config.json` and `/usr/share/imx8-isp/dewarp_config/sensor_dwe_os08a20_1080P_config.json` on the ADIS units