### PR TITLE
Camera Matrix Files

### DIFF
--- a/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_1080P_config.json
+++ b/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_1080P_config.json
@@ -1,0 +1,54 @@
+{
+    "dewarpConfigArray": [
+        {
+            "source_image": {
+                "width": 1920,
+                "height": 1080
+            },
+            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
+            "dewarpType": "FISHEYE_DEWARP",
+            "scale": {
+                "roix": 0,
+                "roiy": 0,
+                "factor": 1.0
+            },
+            "split": {
+                "horizon_line": 540,
+                "vertical_line_up": 960,
+                "vertical_line_down": 960
+            },
+            "bypass": false,
+            "hflip": false,
+            "vflip": false,
+            "camera_matrix": [
+                1258.283,
+                0.0,
+                980.600,
+                0.0,
+                1263.618,
+                528.483,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "distortion_coeff": [
+                -0.02585,
+                -0.01841,
+                -0.002730,
+                0.004726,
+                0.01456
+            ],
+            "perspective": [
+                1.0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1
+            ]
+        }
+    ]
+}

--- a/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_4K_config.json
+++ b/recipes-bsp/imx8-isp/files/dewarp_config/sensor_dwe_os08a20_4K_config.json
@@ -1,0 +1,54 @@
+{
+    "dewarpConfigArray": [
+        {
+            "source_image": {
+                "width": 3840,
+                "height": 2160
+            },
+            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
+            "dewarpType": "FISHEYE_DEWARP",
+            "scale": {
+                "roix": 0,
+                "roiy": 0,
+                "factor": 1.0
+            },
+            "split": {
+                "horizon_line": 540,
+                "vertical_line_up": 960,
+                "vertical_line_down": 960
+            },
+            "bypass": false,
+            "hflip": false,
+            "vflip": false,
+            "camera_matrix": [
+                2516.566,
+                0.0,
+                1961.200,
+                0.0,
+                2527.236,
+                1056.966,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "distortion_coeff": [
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "perspective": [
+                1.0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1
+            ]
+        }
+    ]
+}

--- a/recipes-bsp/imx8-isp/imx8-isp_4.2.2.19.0.bb
+++ b/recipes-bsp/imx8-isp/imx8-isp_4.2.2.19.0.bb
@@ -9,6 +9,8 @@ SRC_URI = "\
     file://imx8-isp.service \
     file://OS08A20_MODES.txt \
     file://Sensor0_Entry.cfg \
+    file://dewarp_config/sensor_dwe_os08a20_4K_config.json \
+    file://dewarp_config/sensor_dwe_os08a20_1080P_config.json \
 "
 SRC_URI[md5sum] = "01f83394df91091f414f122c339c02bc"
 SRC_URI[sha256sum] = "ab65a413f397230010266579df570beac5fde4af430e31fc251d7cf7c8fa2232"
@@ -59,6 +61,9 @@ do_install() {
     cp ${B}/generated/release/bin/*.xml ${D}/${datadir}/imx8-isp
     cp ${B}/generated/release/bin/*.drv ${D}/${datadir}/imx8-isp
     cp ${S}/dewarp/dewarp_config/*.json ${D}/${datadir}/imx8-isp/dewarp_config
+
+    # Copy local dewarp_config over vendor version.
+    cp ${WORKDIR}/dewarp_config/*.json ${D}/${datadir}/imx8-isp/dewarp_config
 
     cp ${B}/generated/release/bin/isp_media_server ${D}/${bindir}
     cp -d ${B}/generated/release/lib/*.so* ${D}/${libdir}


### PR DESCRIPTION
Added the dewarp config files to have the os08a20 camera start with the correct camera matrix for the focal length.
The config files should end up in `/usr/share/imx8-isp/dewarp_config/sensor_dwe_os08a20_4K_config.json` and `/usr/share/imx8-isp/dewarp_config/sensor_dwe_os08a20_1080P_config.json` on the ADIS units